### PR TITLE
# Version 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 3.8.1
+
+### Bugfix
+- "selectForwardInputToEventPair" only reacts on UI selection
+- "selectOutputToSetByEventPair" only reacts on UI selection
+
 ## Release 3.8.0
 
 ### Improvements

--- a/CSK_Module_DigitalIOManager/project.mf.xml
+++ b/CSK_Module_DigitalIOManager/project.mf.xml
@@ -339,12 +339,12 @@ INFO: As this events will be created dynamically, there is no auto completion wi
                     <desc>Add event to listen to and to trigger digital output.</desc>
                 </function>
                 <function name="selectForwardInputToEventPair">
-                    <desc>Select event pair (e.g. in UI table).</desc>
-                    <param desc="Selected pair" multiplicity="1" name="selection" type="string"/>
+                    <desc>Select Input2Event-pair.</desc>
+                    <param desc=" Input2Event-pair to select (via UI selection or port identifier like 'S1DI1')." multiplicity="1" name="selection" type="string"/>
                 </function>
                 <function name="selectOutputToSetByEventPair">
-                    <desc>Select output interface to set for trigger event (see "addTriggerEvent").</desc>
-                    <param desc="Interface to select." multiplicity="1" name="selection" type="string"/>
+                    <desc>Select Event2Trigger-pair.</desc>
+                    <param desc="Event2Trigger-pair to select (via UI selection or port identifier like 'S1DO1')." multiplicity="1" name="selection" type="string"/>
                 </function>
                 <function name="removeTriggerEvent">
                     <desc>Remove event to trigger digital output.</desc>
@@ -382,7 +382,7 @@ INFO: As this events will be created dynamically, there is no auto completion wi
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">3.8.0</meta>
+        <meta key="version">3.8.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_DigitalIOManager/scripts/Configuration/DigitalIOManager/DigitalIOManager_Controller.lua
+++ b/CSK_Module_DigitalIOManager/scripts/Configuration/DigitalIOManager/DigitalIOManager_Controller.lua
@@ -514,14 +514,22 @@ end
 Script.serveFunction("CSK_DigitalIOManager.setDelayForLink", setDelayForLink)
 
 local function selectForwardInputToEventPair(selection)
-  _G.logger:info(nameOfModule .. ": Select input to forward via event: " .. tostring(selection))
-  selectedForwardEventPair = setSelection(selection, '"FromInput":"')
+  if digitalIOManager_Model.parameters.forwardEvent[selection] then
+    selectedForwardEventPair = selection
+  else
+    selectedForwardEventPair = setSelection(selection, '"FromInput":"')
+  end
+  _G.logger:info(nameOfModule .. ": Select input to forward via event: " .. tostring(selectedForwardEventPair))
 end
 Script.serveFunction("CSK_DigitalIOManager.selectForwardInputToEventPair", selectForwardInputToEventPair)
 
 local function selectOutputToSetByEventPair(selection)
-  _G.logger:info(nameOfModule .. ": Select output to set by event: " .. tostring(selection))
-  selectedTriggerEventPair = setSelection(selection, '"SetOutput":"')
+  if digitalIOManager_Model.parameters.triggerEvent[selection] then
+    selectedTriggerEventPair = selection
+  else
+    selectedTriggerEventPair = setSelection(selection, '"SetOutput":"')
+  end
+  _G.logger:info(nameOfModule .. ": Select output to set by event: " .. tostring(selectedTriggerEventPair))
 end
 Script.serveFunction("CSK_DigitalIOManager.selectOutputToSetByEventPair", selectOutputToSetByEventPair)
 

--- a/docu/CSK_Module_DigitalIOManager.html
+++ b/docu/CSK_Module_DigitalIOManager.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_DigitalIOManager 3.8.0</title>
+<title>Documentation - CSK_Module_DigitalIOManager 3.8.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_DigitalIOManager 3.8.0</h1>
+<h1>Documentation - CSK_Module_DigitalIOManager 3.8.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 3.8.0,</span>
-<span id="revdate">2023-07-03</span>
+<span id="revnumber">version 3.8.1,</span>
+<span id="revdate">2023-07-21</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -754,11 +754,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3.8.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3.8.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-07-03</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-07-21</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -1482,7 +1482,7 @@ To remove this link, you need to select this pair via "selectLink" and then to c
 <div class="sect5">
 <h6 id="_short_description_14">Short description</h6>
 <div class="paragraph">
-<p>Select event pair (e.g. in UI table).</p>
+<p>Select Input2Event-pair.</p>
 </div>
 </div>
 <div class="sect5">
@@ -1507,7 +1507,7 @@ To remove this link, you need to select this pair via "selectLink" and then to c
 <td class="tableblock halign-left valign-top"><p class="tableblock">selection</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selected pair</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Input2Event-pair to select (via UI selection or port identifier like 'S1DI1').</p></td>
 </tr>
 </tbody>
 </table>
@@ -1658,7 +1658,7 @@ To remove this link, you need to select this pair via "selectLink" and then to c
 <div class="sect5">
 <h6 id="_short_description_18">Short description</h6>
 <div class="paragraph">
-<p>Select output interface to set for trigger event (see "addTriggerEvent").</p>
+<p>Select Event2Trigger-pair.</p>
 </div>
 </div>
 <div class="sect5">
@@ -1683,7 +1683,7 @@ To remove this link, you need to select this pair via "selectLink" and then to c
 <td class="tableblock halign-left valign-top"><p class="tableblock">selection</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Interface to select.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Event2Trigger-pair to select (via UI selection or port identifier like 'S1DO1').</p></td>
 </tr>
 </tbody>
 </table>
@@ -4732,8 +4732,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 3.8.0<br>
-Last updated 2023-07-03 10:51:37 +0200
+Version 3.8.1<br>
+Last updated 2023-07-21 10:17:38 +0200
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 3.8.1

## Bugfix
- "selectForwardInputToEventPair" only reacts on UI selection
- "selectOutputToSetByEventPair" only reacts on UI selection

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
